### PR TITLE
Feature(Service): add args arguments in options for puppeteer arguments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ class Renderer {
     this.autoOpen = options.autoOpen || false;
     this.dirname = options.dirname;
     this.keepAlive = options.keepAlive || false;
+    this.args = options.args || [];
     this.margin = options.margin || {
       top: '0px',
       right: '0px',
@@ -66,11 +67,10 @@ class Renderer {
     this._maxWorkers = 20;
     this._lastPageSplitClass = 'Page';
 
-    const args = [];
     this.__browserPromise = new Promise(async (resolve) => {
       this.browser = await puppeteer.launch({
         headless: !this.__openBrowser,
-        args,
+        args: this.args,
         defaultViewport: {
           width: this.width,
           height: this.height === 'auto' ? 792 : this.height,


### PR DESCRIPTION
On linux environnement this kind of error can happen : 

```
[0103/121056.845253:ERROR:zygote_host_impl_linux.cc(89)] Running as root without --no-sandbox is not supported. See https://crbug.com/638180

TROUBLESHOOTING: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md

    at onClose (/var/git/prod/test/web-to-pdf/node_modules/puppeteer/lib/Launcher.js:348:14)
    at Interface.helper.addEventListener (/var/git/prod/test/web-to-pdf/node_modules/puppeteer/lib/Launcher.js:337:50)
    at emitNone (events.js:111:20)
    at Interface.emit (events.js:208:7)
    at Interface.close (readline.js:368:8)
    at Socket.onend (readline.js:147:10)
    at emitNone (events.js:111:20)
    at Socket.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1064:12)
    at _combinedTickCallback (internal/process/next_tick.js:139:11)
    at process._tickCallback (internal/process/next_tick.js:181:9)
(node:23951) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 6)
``` 

---

Now to fix it  `--no-sandbox ` as argument is enough and works.

PS: I let you dump the package version